### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,19 +65,4 @@ typings/
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 
-# next.js build output
-.next
 
-# nuxt.js build output
-.nuxt
-
-# vuepress build output
-.vuepress/dist
-
-# Serverless directories
-.serverless
-
-# FuseBox cache
-.fusebox/
-
-# End of https://www.gitignore.io/api/node


### PR DESCRIPTION
Qué ha cambiado?
Agregamos al gitignore soporte para Node.js
- [ ] Frontend
- [ ] Backend
- [x ] Configuración del server

#Como puedo probar los cambios?
Por ejemplo los archivos y la carpeta node_modules ya no se suben al repo, ver el archivo .gitignore completo.
